### PR TITLE
update to final version of dashboard (2.0)

### DIFF
--- a/charts/kubernetes-dashboard/README.md
+++ b/charts/kubernetes-dashboard/README.md
@@ -93,6 +93,8 @@ Parameter                           | Description                               
 `ingress.hosts`                     | Dashboard Hostnames                                                                                                         | `nil`
 `ingress.tls`                       | Ingress TLS configuration                                                                                                    | `[]`
 `metricsScraper.enabled`            | Wether to enable dashboard-metrics-scraper                                                                                  | `false`
+`metricsScraper.image.repository`   | Repository for metrics-scraper image                                                                                        | `kubernetesui/metrics-scraper`
+`metricsScraper.image.tag`          | Repository for metrics-scraper image tag                                                                                    | `v1.0.4`
 `metrics-server.enabled`            | Wether to enable metrics-server                                                                                             | `false`
 `rbac.create`                       | Create & use RBAC resources                                                                                                 | `true`
 `rbac.clusterRoleMetrics`           | If set, an additional cluster role / role binding will be created to access metrics.                                        | `true`

--- a/charts/kubernetes-dashboard/values.yaml
+++ b/charts/kubernetes-dashboard/values.yaml
@@ -19,7 +19,7 @@
 
 image:
   repository: kubernetesui/dashboard
-  tag: v2.0.0-rc7
+  tag: v2.0.0
   pullPolicy: IfNotPresent
   pullSecrets: []
 
@@ -141,7 +141,7 @@ metricsScraper:
   revisionHistoryLimit: 10
   image:
     repository: kubernetesui/metrics-scraper
-    tag: v1.0.3
+    tag: v1.0.4
   resources: {}
 
 ## Optional Metrics Server sub-chart


### PR DESCRIPTION
and bump metrics scrapper vers to 1.0.4
ideally, requirements.lock should be also updated (using helm upgrade) to get the new metrics server version (2.11.1)