### PR TITLE
Adding override for ingress paths

### DIFF
--- a/charts/kubernetes-dashboard/Chart.yaml
+++ b/charts/kubernetes-dashboard/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubernetes-dashboard
-version: 2.0.0
+version: 2.0.0-1
 appVersion: 2.0.0
 description: General-purpose web UI for Kubernetes clusters
 keywords:

--- a/charts/kubernetes-dashboard/README.md
+++ b/charts/kubernetes-dashboard/README.md
@@ -80,7 +80,7 @@ Parameter                           | Description                               
 `podAnnotations`                    | Annotations to be added to pods                                                                                             | `seccomp.security.alpha.kubernetes.io/pod: 'runtime/default'}`
 `nodeSelector`                      | node labels for pod assignment                                                                                              | `{}`
 `tolerations`                       | List of node taints to tolerate (requires Kubernetes >= 1.6)                                                                | `[]`
-`affinity`                           | Affinity for pod assignment                                                                                                  | `[]`
+`affinity`                          | Affinity for pod assignment                                                                                                 | `[]`
 `priorityClassName`                 | Name of Priority Class to assign pods                                                                                       | `nil`
 `resources`                         | Pod resource requests & limits                                                                                              | `limits: {cpu: 2, memory: 100Mi}, requests: {cpu: 100m, memory: 100Mi}`
 `protocolHttp`                      | Serve application over HTTP without TLS                                                                                     | `false`
@@ -91,8 +91,9 @@ Parameter                           | Description                               
 `ingress.labels`                    | Add custom labels                                                                                                           | `[]`
 `ingress.enabled`                   | Enable ingress controller resource                                                                                          | `false`
 `ingress.paths`                     | Paths to match against incoming requests. Both `/` and `/*` are required to work on gce ingress.                            | `[/]`
+`ingress.paths_custom`              | Override for the ingress paths                                                                                              | `[]`
 `ingress.hosts`                     | Dashboard Hostnames                                                                                                         | `nil`
-`ingress.tls`                       | Ingress TLS configuration                                                                                                    | `[]`
+`ingress.tls`                       | Ingress TLS configuration                                                                                                   | `[]`
 `metricsScraper.enabled`            | Wether to enable dashboard-metrics-scraper                                                                                  | `false`
 `metricsScraper.image.repository`   | Repository for metrics-scraper image                                                                                        | `kubernetesui/metrics-scraper`
 `metricsScraper.image.tag`          | Repository for metrics-scraper image tag                                                                                    | `v1.0.4`
@@ -102,7 +103,7 @@ Parameter                           | Description                               
 `rbac.clusterReadOnlyRole`          | If set, an additional cluster role / role binding will be created with read only permissions to all resources listed inside.| `false`
 `serviceAccount.create`             | Whether a new service account name that the agent will use should be created.                                               | `true`
 `serviceAccount.name`               | Service account to be used. If not set and serviceAccount.create is `true` a name is generated using the fullname template. |
-`livenessProbe.initialDelaySeconds` | Number of seconds to wait before sending first probe                                                                         | `30`
+`livenessProbe.initialDelaySeconds` | Number of seconds to wait before sending first probe                                                                        | `30`
 `livenessProbe.timeoutSeconds`      | Number of seconds to wait for probe response                                                                                | `30`
 `podDisruptionBudget.enabled`       | Create a PodDisruptionBudget                                                                                                | `false`
 `podDisruptionBudget.minAvailable`  | Minimum available instances; ignored if there is no PodDisruptionBudget                                                     |
@@ -110,7 +111,7 @@ Parameter                           | Description                               
 `securityContext`                   | PodSecurityContext for pod level securityContext                                                                            | `nil`
 `dashboardContainerSecurityContext` | SecurityContext for the kubernetes dashboard container                                                                      | `{allowPrivilegeEscalation:false, readOnlyRootFilesystem: true, runAsUser: 1001, runAsGroup: 2001}`
 `metricsScraperContainerSecurityContext` | SecurityContext for the kubernetes dashboard metrics scraper container                                                 | `{allowPrivilegeEscalation:false, readOnlyRootFilesystem: true, runAsUser: 1001, runAsGroup: 2001}`
-`networkPolicy.enabled`                     | Whether to create a network policy that allows access to the service                                                        | `false`
+`networkPolicy.enabled`             | Whether to create a network policy that allows access to the service                                                        | `false`
 
 
 

--- a/charts/kubernetes-dashboard/templates/ingress.yaml
+++ b/charts/kubernetes-dashboard/templates/ingress.yaml
@@ -43,21 +43,29 @@ spec:
     - host: {{ $host }}
       http:
         paths:
+  {{- if len ($.Values.ingress.paths_custom) }}
+  {{- "\n" }}{{ tpl (toYaml $.Values.ingress.paths_custom | indent 10) $ }}
+  {{- else }}
   {{- range $p := $paths }}
           - path: {{ $p }}
             backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
+  {{- end -}}
   {{- end -}}
   {{- end -}}
   {{- else }}
     - http:
         paths:
+  {{- if len (.Values.ingress.paths_custom) }}
+  {{- "\n" }}{{ tpl (toYaml .Values.ingress.paths_custom | indent 10) . }}
+  {{- else }}
   {{- range $p := $paths }}
           - path: {{ $p }}
             backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
+  {{- end -}}
   {{- end -}}
   {{- end -}}
   {{- if .Values.ingress.tls }}

--- a/charts/kubernetes-dashboard/values.yaml
+++ b/charts/kubernetes-dashboard/values.yaml
@@ -119,6 +119,18 @@ ingress:
     - /
   #  - /*
 
+  ## Custom Kubernetes Dashboard Ingress paths
+  ##
+  paths_custom: []
+  #  - backend:
+  #      serviceName: ssl-redirect
+  #      servicePort: use-annotation
+  #  - backend:
+  #      serviceName: >-
+  #        {{ include "kubernetes-dashboard.fullname" . }}
+  #      # Don't use string here, use only integer value!
+  #      servicePort: 443
+
   ## Kubernetes Dashboard Ingress hostnames
   ## Must be provided if Ingress is enabled
   ##


### PR DESCRIPTION
This PR is adding the possibility to override the default Ingress paths with a new block of paths defined as YAML data structure. This allows to configure the Ingress resource to work with the AWS ALB Ingress Controller to automatically [redirect HTTP traffic to HTTPS](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/tasks/ssl_redirect/) on the load balancer.